### PR TITLE
Add figcaption:alt and figcaption:title options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ console.log(res);
   e.g.: `<figure data-type="image">`. This can be useful for applying a special
   styling for different kind of figures.
 
-- `figcaption`: Set `figcaption` to `true` to use the title as a `<figcaption>` block after the image. E.g.: `![This is an alt](fig.png "This is a caption")` renders to
+- `figcaption`: Set `figcaption` to `true` or `"title"` to use the title as a `<figcaption>` block after the image; set `figcaption` to `"alt"` to use the alt text as a `<figcaption>`. E.g.: `![This is an alt](fig.png "This is a title")` renders to
 
 ```html
 <figure>
     <img src="fig.png" alt="This is an alt">
-    <figcaption>This is a caption</figcaption>
+    <figcaption>This is a title</figcaption>
 </figure>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "markdown-it-image-figures",
       "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "microbundle --target node --compress --sourcemap false",
     "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
     "dev": "microbundle watch",
+    "pretest": "npm run build",
     "test": "mocha ./test/index.test.js && npm run test:exports",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs",
     "lint": "eslint src/*.js lazy-example.js",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,7 +34,7 @@ describe('markdown-it-image-figures', function() {
     assert.strictEqual(res, expected);
   });
 
-  it('should add convert alt text into a figcaption when opts.figcaption is set', function() {
+  it('should convert title text into a figcaption when opts.figcaption is true', function() {
     md = mdIT().use(implicitFigures, { figcaption: true });
     const src = '![This is an alt](fig.png "This is a caption")';
     const expected = '<figure><img src="fig.png" alt="This is an alt"><figcaption>This is a caption</figcaption></figure>\n';
@@ -42,13 +42,55 @@ describe('markdown-it-image-figures', function() {
     assert.strictEqual(res, expected);
   });
 
-  it('should convert alt text for each image into a figcaption when opts.figcaption is set', function() {
+  it('should convert title text for each image into a figcaption when opts.figcaption is true', function() {
     md = mdIT().use(implicitFigures, { figcaption: true });
     const src = '![alt 1](fig.png "caption 1")\n\n![alt 2](fig2.png "caption 2")';
     const expected = '<figure><img src="fig.png" alt="alt 1"><figcaption>caption 1</figcaption></figure>\n<figure><img src="fig2.png" alt="alt 2"><figcaption>caption 2</figcaption></figure>\n';
     const res = md.render(src);
     assert.strictEqual(res, expected);
   });
+
+  it('should convert title text into a figcaption when opts.figcaption is "title"', function() {
+    md = mdIT().use(implicitFigures, { figcaption: 'title' });
+    const src = '![This is an alt](fig.png "This is a caption")';
+    const expected = '<figure><img src="fig.png" alt="This is an alt"><figcaption>This is a caption</figcaption></figure>\n';
+    const res = md.render(src);
+    assert.strictEqual(res, expected);
+  });
+
+  it('should convert title text for each image into a figcaption when opts.figcaption is "title"', function() {
+    md = mdIT().use(implicitFigures, { figcaption: 'title' });
+    const src = '![alt 1](fig.png "caption 1")\n\n![alt 2](fig2.png "caption 2")';
+    const expected = '<figure><img src="fig.png" alt="alt 1"><figcaption>caption 1</figcaption></figure>\n<figure><img src="fig2.png" alt="alt 2"><figcaption>caption 2</figcaption></figure>\n';
+    const res = md.render(src);
+    assert.strictEqual(res, expected);
+  });
+
+  it('should convert alt text into a figcaption when opts.figcaption is set to "alt"', function() {
+    md = mdIT().use(implicitFigures, { figcaption: 'alt' });
+    const src = '![This is an alt](fig.png "This is a caption")';
+    const expected = '<figure><img src="fig.png" alt="This is an alt"><figcaption>This is an alt</figcaption></figure>\n';
+    const res = md.render(src);
+    assert.strictEqual(res, expected);
+  });
+
+  it('should convert alt text for each image into a figcaption when opts.figcaption is set to "alt"', function() {
+    md = mdIT().use(implicitFigures, { figcaption: 'alt' });
+    const src = '![alt 1](fig.png "caption 1")\n\n![alt 2](fig2.png "caption 2")';
+    const expected = '<figure><img src="fig.png" alt="alt 1"><figcaption>alt 1</figcaption></figure>\n<figure><img src="fig2.png" alt="alt 2"><figcaption>alt 2</figcaption></figure>\n';
+    const res = md.render(src);
+    assert.strictEqual(res, expected);
+  });
+
+  it('should throw an error when opts.figcaption is "ttitle"', function () {
+    md = mdIT().use(implicitFigures, { figcaption: 'ttitle' });
+    const src = '![alt 1](fig.png "caption 1")\n\n![alt 2](fig2.png "caption 2")';
+
+    assert.throws(() => {
+      md.render(src);
+    }, /figcaption must be one of: true,false,alt,title/);
+  });
+
 
   it('should add incremental tabindex to figures when opts.tabindex is set', function() {
     md = mdIT().use(implicitFigures, { tabindex: true });


### PR DESCRIPTION
Made the following changes:

1. Added support for `figcaption: "alt"` and `figcaption: "title"`
2. Throw an error if `figcaption` is set to anything other than `true`, `false`, `"alt"`, or `"title"`
3. Added tests for `figcaption: "alt"` and `figcaption: "title"` as well as an invalid value
4. Updated README to reflect new option values

Fixes #11